### PR TITLE
Updated Vagrantfile curl for Torrent

### DIFF
--- a/en_us/install_operations/source/installation/devstack/install_devstack.rst
+++ b/en_us/install_operations/source/installation/devstack/install_devstack.rst
@@ -149,7 +149,7 @@ client, follow these steps.
 
    .. code-block:: bash
 
-     curl -O https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile
+     curl -L https://raw.github.com/edx/configuration/master/vagrant/release/devstack/Vagrantfile > Vagrantfile
 
 #. Download the torrent file for the latest Open edX release. For information
    about the latest Open edX releases and to download torrent files for them,


### PR DESCRIPTION
## [DOC-XXXX](https://openedx.atlassian.net/browse/DOC-XXXX)

The curl command for the Vagrantfile needed the -L instead of the -o so that the file isn't empty.
### 3rd August 2016

If the release date of a feature is known or estimated, provide it to give reviewers guidance on turnaround time.
### Reviewers

Possible roles follow. The PR submitter checks the boxes after each reviewer finishes and gives :+1:. 
- [ ] Subject matter expert: 
- [ ] Subject matter expert: 
- [ ] Doc team review (sanity check/copy edit/dev edit): @catong @lamagnifica @pdesjardins @srpearce
- [ ] Product review:
- [ ] Partner support: 
- [ ] PM review: 

FYI: Tag anyone else who might be interested in this PR here.
### Testing
- [ ] Ran ./run_tests.sh without warnings or errors
### HTML Version (optional)
- [ ] Build an RTD draft for your branch and add a link here
### Sandbox (optional)
- [ ] Point to or build a sandbox for the software change and add a link here
### Post-review
- [ ] Add a comment with the description of this change or link this PR to the next release notes task.
- [ ] Squash commits

Updated Vagrantfile curl for Torrent download
